### PR TITLE
don't log trending page

### DIFF
--- a/src/TrendingRequester.js
+++ b/src/TrendingRequester.js
@@ -12,7 +12,6 @@ class TrendingRequester {
         }
         try {
             if (geoLocation !== null) {
-                console.log(trending_page+`?persist_gl=1&gl=${geoLocation}`)
                 return await axios.get(trending_page+`?persist_gl=1&gl=${geoLocation}`, config)
             } else {
                 return await axios.get(trending_page, config)


### PR DESCRIPTION
It makes sense to log it when testing changes to this package, but for use in production apps this is really not necessary.